### PR TITLE
Fixed issue with blue screen after reopen serial port

### DIFF
--- a/src/port/Port.java
+++ b/src/port/Port.java
@@ -4,7 +4,7 @@ import com.fazecast.jSerialComm.SerialPort;
 
 public class Port
 {
-    private SerialPort serialPort = null;
+    private volatile SerialPort serialPort = null;
 
     private int baudRate = 115200;
 
@@ -39,17 +39,26 @@ public class Port
         }
     }
 
-    byte readByte()
+    byte readByte() throws Exception
     {
         byte[] oneChar = new byte[1];
 
         if(null != serialPort)
         {
             if ( serialPort.isOpen() )
-                serialPort.readBytes(oneChar, 1);
+            {
+                if ( -1 < serialPort.readBytes(oneChar, 1) )
+                {
+                    return oneChar[0];
+                }
+                else
+                {
+                    oneChar[0] = 1;
+                }
+            }
         }
 
-        return oneChar[0];
+        throw new Exception("Port is closed.");
     }
 
     public boolean open(String serialPortName, int dataBits, int stopBits, int parityBits)
@@ -59,7 +68,7 @@ public class Port
             serialPort = SerialPort.getCommPort(serialPortName);
             serialPort.setComPortParameters(baudRate, dataBits, stopBits, parityBits);
 
-            serialPort.setComPortTimeouts(SerialPort.TIMEOUT_READ_SEMI_BLOCKING, 100, 100);
+            serialPort.setComPortTimeouts(SerialPort.TIMEOUT_READ_BLOCKING, 0, 0);
 
             stopReading = false;
 
@@ -85,7 +94,7 @@ public class Port
             {
                 stopReading = true;
 
-                serialPort = null;
+                //serialPort = null;
             }
         }
 

--- a/src/port/PortReader.java
+++ b/src/port/PortReader.java
@@ -37,7 +37,7 @@ public class PortReader extends Port
         return PortReaderINSTANCE;
     }
 
-    private int readFrame()
+    private int readFrame() throws Exception
     {
         byte element = 0;                                           // variable for read one byte
         short cntBytes = 0;
@@ -47,7 +47,7 @@ public class PortReader extends Port
 
         while ((START_BYTE & 0xFF) != (element & 0xFF))             // & 0xFF <- to obtain a unsigned value
         {
-            element = readByte();
+                element = readByte();
         }
 
         bufferIn.clear();
@@ -145,15 +145,28 @@ public class PortReader extends Port
     public void startReading()
     {
         // create a new thread and listen for frame, then display it in Log tab
-        new Thread(() ->
+        Thread thread = new Thread(() ->
         {
+            System.out.println("Started reading thread.");
+
             bufferIn = new ArrayList<>();
 
             while(!stopReading)
             {
-                Log.getInstance().log("Overall received and decoded number of bytes: " + readFrame());
+                try
+                {
+                    Log.getInstance().log("Overall received and decoded number of bytes: " + readFrame());
+                }
+                catch (Exception e)
+                {
+                    break;
+                }
             }
 
-        }).start();
+            System.out.println("Stopped reading thread.");
+
+        });
+        thread.setName("Reading Thread");
+        thread.start();
     }
 }


### PR DESCRIPTION
At this moment it's dealt by using exceptions, but before reopen again serial port it's need any action in program (e.g., window shift) - it's need because only after that is finished thread which is responsible of reading frames, but in the nearest future there are plans to solve this issue.